### PR TITLE
Add Swetrix host to nginx proxy config example

### DIFF
--- a/docs/adblockers/guides/nginx.md
+++ b/docs/adblockers/guides/nginx.md
@@ -22,12 +22,15 @@ server {
   # Using the Cloudflare DNS resolver, you can remove this line if you already use a resolver in your config, or change it to a resolver of your choice.
   resolver 1.1.1.1;
 
-  set $swetrix_script_url  https://swetrix.org/swetrix.js;
-  set $swetrix_api_url https://api.swetrix.com;
+  set $swetrix_script_host swetrix.org;
+  set $swetrix_api_host api.swetrix.com;
+  set $swetrix_script_url https://$swetrix_script_host/swetrix.js;
+  set $swetrix_api_url https://$swetrix_api_host;
 
   location = /script.js {
     proxy_pass $swetrix_script_url;
-    proxy_set_header Host $host;
+    proxy_set_header Host $swetrix_script_host;
+    proxy_ssl_server_name on;
     proxy_buffering on;
 
     # Cache the script for 6 hours, as long as swetrix.org returns a valid response
@@ -37,7 +40,7 @@ server {
   }
 
   location /log {
-    proxy_set_header Host                $host;
+    proxy_set_header Host                $swetrix_api_host;
     proxy_set_header X-Client-IP-Address $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto   $scheme;
 


### PR DESCRIPTION
When using nginx as a proxy, the request is being blocked from Cloudflare if the wrong host is given. Just passing on the `$host` (your own host) results in a 403 from Cloudflare. To prevent this, the correct Swetrix hosts should be passed.

I've updated the nginx variables to reflect this change:

```
set $swetrix_script_host swetrix.org;
set $swetrix_api_host api.swetrix.com;
set $swetrix_script_url https://$swetrix_script_host/swetrix.js;
set $swetrix_api_url https://$swetrix_api_host;
```

Setting the host as it's own variable is important in nginx, so that the resolver can update it accordingly.

I have also added `proxy_ssl_server_name on;` to the scripts location block.